### PR TITLE
Enable security issues scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Issue Sentinel
 
-Easily connect to the smart Issue Sentinel with this GitHub Action. It helps you handle similar issues in your repository efficiently.
+Easily connect to the smart Issue Sentinel with this GitHub Action. It helps you handle similar issues and security issues in your repository efficiently.
 
 ## Use the Issue Sentinel
 
@@ -29,6 +29,8 @@ To use the Issue Sentinel, follow these steps:
             uses: Azure/issue-sentinel@v1
             with:
               password: ${{secrets.ISSUE_SENTINEL_PASSWORD}}
+              enable-similar-issues-scanning: true # Scan similar issues in your repo, default: true
+              enable-security-issues-scanning: true # Scan security issues in your repo, default: false
     ```
 
 ## Notes for developers

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,14 @@ inputs:
     description: 'The GitHub token used to create an authenticated client'
     default: ${{ github.token }}
     required: false
+  enable-similar-issues-scanning: 
+    description: 'Enable similar issues scanning'
+    default: 'true'
+    required: false
+  enable-security-issues-scanning: 
+    description: 'Enable security issues scanning'
+    default: 'false'
+    required: false
 branding:
   icon: 'shield'
   color: 'blue'

--- a/dist/index.js
+++ b/dist/index.js
@@ -31577,12 +31577,16 @@ function main() {
             }
             const issue = context.payload.issue;
             core.debug(`Issue: ${JSON.stringify(issue)}`);
-            const { owner, repo } = github.context.repo;
+            const { owner, repo } = context.repo;
             if (enable_similar_issues_scanning === 'true') {
                 yield handleSimilarIssuesScanning(issue, owner, repo, password, token, botUrl, context);
             }
             if (enable_security_issues_scanning === 'true') {
-                core.info(`eventName: ${context.eventName}`);
+                core.debug(`Issue trigger: ${context.payload.action}`);
+                if (context.payload.action !== 'opened') {
+                    core.info('Skip security issues scanning for edited and closed issue.');
+                    return;
+                }
                 yield handleSecurityIssuesScanning(issue, owner, repo, password, token, botUrl, context);
             }
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -31673,13 +31673,13 @@ function handleSecurityIssuesScanning(issue, owner, repo, password, token, botUr
             core.info('This issue has already been labeled as Security-Issue. Skip this issue.');
             return;
         }
-        const ifsecurity = (yield axios_1.default.post(botUrl + '/security/', {
+        const if_security = (yield axios_1.default.post(botUrl + '/security/', {
             'raw': issue,
             'password': password
-        })).data.predict;
+        })).data.security;
         core.info('Search the security issues by the issue sentinel successfully.');
-        core.debug(`Response: ${ifsecurity}`);
-        if (!ifsecurity) {
+        core.debug(`Response: ${if_security}`);
+        if (!if_security) {
             core.info('Not a security issue.');
             return;
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -31578,117 +31578,127 @@ function main() {
             const issue = context.payload.issue;
             core.debug(`Issue: ${JSON.stringify(issue)}`);
             const { owner, repo } = github.context.repo;
-            let owner_repo = `${owner}/${repo}`;
-            owner_repo = owner_repo.toLowerCase();
-            core.debug(`owner/repo: ${owner_repo}`);
             if (enable_similar_issues_scanning === 'true') {
-                const if_closed = issue.state === 'closed';
-                if (if_closed) {
-                    yield axios_1.default.post(botUrl + '/update_issue/', {
-                        'raw': issue,
-                        'password': password
-                    });
-                    core.info('This issue was closed. Update it to issue sentinel.');
-                    return;
-                }
-                const if_replied = (yield axios_1.default.post(botUrl + '/check_reply/', {
-                    'repo': owner_repo,
-                    'issue': issue.number,
-                    'password': password
-                })).data.result;
-                core.info('Check if this issue was already replied by the sentinel: ' + if_replied.toString());
-                if (if_replied) {
-                    yield axios_1.default.post(botUrl + '/update_issue/', {
-                        'raw': issue,
-                        'password': password
-                    });
-                    core.info('This issue was already replied by the sentinel. Update the edited content to sentinel and skip this issue.');
-                    return;
-                }
-                const prediction = (yield axios_1.default.post(botUrl + '/search/', {
-                    'raw': issue,
-                    'password': password,
-                    'verify': true
-                })).data.predict;
-                core.info('Search by the issue sentinel successfully.');
-                core.debug(`Response: ${prediction}`);
-                if (!prediction || prediction.length === 0) {
-                    core.info('No prediction found');
-                    return;
-                }
-                let message = 'Here are some similar issues that might help you. Please check if they can solve your problem.\n';
-                for (const item of prediction) {
-                    message += `- #${item[item.length - 1]}\n`;
-                }
-                message = message.trimEnd();
-                const octokit = github.getOctokit(token);
-                const issueNumber = context.payload.issue.number;
-                yield octokit.rest.issues.createComment({
-                    owner,
-                    repo,
-                    issue_number: issueNumber,
-                    body: message
-                });
-                core.info(`Comment sended to issue #${issueNumber}`);
-                const labels = ["Similar-Issue"];
-                yield octokit.rest.issues.addLabels({
-                    owner,
-                    repo,
-                    issue_number: issueNumber,
-                    labels
-                });
-                core.info(`Label added to issue #${issueNumber}`);
-                yield axios_1.default.post(botUrl + '/add_reply/', {
-                    'repo': owner_repo,
-                    'issue': issue.number,
-                    'password': password
-                });
-                core.info('Save replied issue to issue sentinel.');
+                yield handleSimilarIssuesScanning(issue, owner, repo, password, token, botUrl, context);
             }
             if (enable_security_issues_scanning === 'true') {
-                const octokit = github.getOctokit(token);
-                const issueNumber = context.payload.issue.number;
-                const { data: existedLabels } = yield octokit.rest.issues.listLabelsOnIssue({
-                    owner,
-                    repo,
-                    issue_number: issueNumber,
-                });
-                const labelExists = existedLabels.some((label) => label.name === "Security-Issue");
-                if (labelExists) {
-                    core.info('This issue has already been labeled as Security-Issue. Skip this issue.');
-                    return;
-                }
-                const ifsecurity = (yield axios_1.default.post(botUrl + '/security/', {
-                    'raw': issue,
-                    'password': password
-                })).data.predict;
-                core.info('Search the security issues by the issue sentinel successfully.');
-                core.debug(`Response: ${ifsecurity}`);
-                if (!ifsecurity) {
-                    core.info('Not a security issue.');
-                    return;
-                }
-                let message = 'This issue is related to security. Please pay attention.\n';
-                yield octokit.rest.issues.createComment({
-                    owner,
-                    repo,
-                    issue_number: issueNumber,
-                    body: message
-                });
-                core.info(`Comment sended to issue #${issueNumber}`);
-                const labels = ["Security-Issue"];
-                yield octokit.rest.issues.addLabels({
-                    owner,
-                    repo,
-                    issue_number: issueNumber,
-                    labels
-                });
-                core.info(`Label added to issue #${issueNumber}`);
+                yield handleSecurityIssuesScanning(issue, owner, repo, password, token, botUrl, context);
             }
         }
         catch (error) {
             core.setFailed(error.message);
         }
+    });
+}
+function handleSimilarIssuesScanning(issue, owner, repo, password, token, botUrl, context) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let owner_repo = `${owner}/${repo}`;
+        owner_repo = owner_repo.toLowerCase();
+        core.debug(`owner/repo: ${owner_repo}`);
+        const if_closed = issue.state === 'closed';
+        if (if_closed) {
+            yield axios_1.default.post(botUrl + '/update_issue/', {
+                'raw': issue,
+                'password': password
+            });
+            core.info('This issue was closed. Update it to issue sentinel.');
+            return;
+        }
+        const if_replied = (yield axios_1.default.post(botUrl + '/check_reply/', {
+            'repo': owner_repo,
+            'issue': issue.number,
+            'password': password
+        })).data.result;
+        core.info('Check if this issue was already replied by the sentinel: ' + if_replied.toString());
+        if (if_replied) {
+            yield axios_1.default.post(botUrl + '/update_issue/', {
+                'raw': issue,
+                'password': password
+            });
+            core.info('This issue was already replied by the sentinel. Update the edited content to sentinel and skip this issue.');
+            return;
+        }
+        const prediction = (yield axios_1.default.post(botUrl + '/search/', {
+            'raw': issue,
+            'password': password,
+            'verify': true
+        })).data.predict;
+        core.info('Search by the issue sentinel successfully.');
+        core.debug(`Response: ${prediction}`);
+        if (!prediction || prediction.length === 0) {
+            core.info('No prediction found');
+            return;
+        }
+        let message = 'Here are some similar issues that might help you. Please check if they can solve your problem.\n';
+        for (const item of prediction) {
+            message += `- #${item[item.length - 1]}\n`;
+        }
+        message = message.trimEnd();
+        const octokit = github.getOctokit(token);
+        const issueNumber = context.payload.issue.number;
+        yield octokit.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number: issueNumber,
+            body: message
+        });
+        core.info(`Comment sended to issue #${issueNumber}`);
+        const labels = ["Similar-Issue"];
+        yield octokit.rest.issues.addLabels({
+            owner,
+            repo,
+            issue_number: issueNumber,
+            labels
+        });
+        core.info(`Label added to issue #${issueNumber}`);
+        yield axios_1.default.post(botUrl + '/add_reply/', {
+            'repo': owner_repo,
+            'issue': issue.number,
+            'password': password
+        });
+        core.info('Save replied issue to issue sentinel.');
+    });
+}
+function handleSecurityIssuesScanning(issue, owner, repo, password, token, botUrl, context) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const octokit = github.getOctokit(token);
+        const issueNumber = context.payload.issue.number;
+        const { data: existedLabels } = yield octokit.rest.issues.listLabelsOnIssue({
+            owner,
+            repo,
+            issue_number: issueNumber,
+        });
+        const labelExists = existedLabels.some((label) => label.name === "Security-Issue");
+        if (labelExists) {
+            core.info('This issue has already been labeled as Security-Issue. Skip this issue.');
+            return;
+        }
+        const ifsecurity = (yield axios_1.default.post(botUrl + '/security/', {
+            'raw': issue,
+            'password': password
+        })).data.predict;
+        core.info('Search the security issues by the issue sentinel successfully.');
+        core.debug(`Response: ${ifsecurity}`);
+        if (!ifsecurity) {
+            core.info('Not a security issue.');
+            return;
+        }
+        let message = 'This issue is related to security. Please pay attention.\n';
+        yield octokit.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number: issueNumber,
+            body: message
+        });
+        core.info(`Comment sended to issue #${issueNumber}`);
+        const labels = ["Security-Issue"];
+        yield octokit.rest.issues.addLabels({
+            owner,
+            repo,
+            issue_number: issueNumber,
+            labels
+        });
+        core.info(`Label added to issue #${issueNumber}`);
     });
 }
 main();

--- a/dist/index.js
+++ b/dist/index.js
@@ -31565,6 +31565,11 @@ function main() {
             const password = core.getInput('password');
             //TODO: use github token for authentication
             const token = core.getInput('github-token', { required: true });
+            const enable_similar_issues_scanning = core.getInput('enable-similar-issues-scanning');
+            const enable_security_issues_scanning = core.getInput('enable-security-issues-scanning');
+            if (enable_similar_issues_scanning !== 'true' && enable_security_issues_scanning !== 'true') {
+                throw new Error('Invalid input! Both similar issues scanning and security issues scanning are disabled. Please enable at least one of them.');
+            }
             const botUrl = 'https://similar-bot-prod.calmhill-ec497646.eastus.azurecontainerapps.io';
             const context = github.context;
             if (!context.payload.issue) {
@@ -31576,68 +31581,110 @@ function main() {
             let owner_repo = `${owner}/${repo}`;
             owner_repo = owner_repo.toLowerCase();
             core.debug(`owner/repo: ${owner_repo}`);
-            const if_closed = issue.state === 'closed';
-            if (if_closed) {
-                yield axios_1.default.post(botUrl + '/update_issue/', {
+            if (enable_similar_issues_scanning === 'true') {
+                const if_closed = issue.state === 'closed';
+                if (if_closed) {
+                    yield axios_1.default.post(botUrl + '/update_issue/', {
+                        'raw': issue,
+                        'password': password
+                    });
+                    core.info('This issue was closed. Update it to issue sentinel.');
+                    return;
+                }
+                const if_replied = (yield axios_1.default.post(botUrl + '/check_reply/', {
+                    'repo': owner_repo,
+                    'issue': issue.number,
+                    'password': password
+                })).data.result;
+                core.info('Check if this issue was already replied by the sentinel: ' + if_replied.toString());
+                if (if_replied) {
+                    yield axios_1.default.post(botUrl + '/update_issue/', {
+                        'raw': issue,
+                        'password': password
+                    });
+                    core.info('This issue was already replied by the sentinel. Update the edited content to sentinel and skip this issue.');
+                    return;
+                }
+                const prediction = (yield axios_1.default.post(botUrl + '/search/', {
                     'raw': issue,
+                    'password': password,
+                    'verify': true
+                })).data.predict;
+                core.info('Search by the issue sentinel successfully.');
+                core.debug(`Response: ${prediction}`);
+                if (!prediction || prediction.length === 0) {
+                    core.info('No prediction found');
+                    return;
+                }
+                let message = 'Here are some similar issues that might help you. Please check if they can solve your problem.\n';
+                for (const item of prediction) {
+                    message += `- #${item[item.length - 1]}\n`;
+                }
+                message = message.trimEnd();
+                const octokit = github.getOctokit(token);
+                const issueNumber = context.payload.issue.number;
+                yield octokit.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    body: message
+                });
+                core.info(`Comment sended to issue #${issueNumber}`);
+                const labels = ["Similar-Issue"];
+                yield octokit.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    labels
+                });
+                core.info(`Label added to issue #${issueNumber}`);
+                yield axios_1.default.post(botUrl + '/add_reply/', {
+                    'repo': owner_repo,
+                    'issue': issue.number,
                     'password': password
                 });
-                core.info('This issue was closed. Update it to issue sentinel.');
-                return;
+                core.info('Save replied issue to issue sentinel.');
             }
-            const if_replied = (yield axios_1.default.post(botUrl + '/check_reply/', {
-                'repo': owner_repo,
-                'issue': issue.number,
-                'password': password
-            })).data.result;
-            core.info('Check if this issue was already replied by the sentinel: ' + if_replied.toString());
-            if (if_replied) {
-                yield axios_1.default.post(botUrl + '/update_issue/', {
+            if (enable_security_issues_scanning === 'true') {
+                const octokit = github.getOctokit(token);
+                const issueNumber = context.payload.issue.number;
+                const { data: existedLabels } = yield octokit.rest.issues.listLabelsOnIssue({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                });
+                const labelExists = existedLabels.some((label) => label.name === "Security-Issue");
+                if (labelExists) {
+                    core.info('This issue has already been labeled as Security-Issue. Skip this issue.');
+                    return;
+                }
+                const ifsecurity = (yield axios_1.default.post(botUrl + '/security/', {
                     'raw': issue,
                     'password': password
+                })).data.predict;
+                core.info('Search the security issues by the issue sentinel successfully.');
+                core.debug(`Response: ${ifsecurity}`);
+                if (!ifsecurity) {
+                    core.info('Not a security issue.');
+                    return;
+                }
+                let message = 'This issue is related to security. Please pay attention.\n';
+                yield octokit.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    body: message
                 });
-                core.info('This issue was already replied by the sentinel. Update the edited content to sentinel and skip this issue.');
-                return;
+                core.info(`Comment sended to issue #${issueNumber}`);
+                const labels = ["Security-Issue"];
+                yield octokit.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    labels
+                });
+                core.info(`Label added to issue #${issueNumber}`);
             }
-            const prediction = (yield axios_1.default.post(botUrl + '/search/', {
-                'raw': issue,
-                'password': password,
-                'verify': true
-            })).data.predict;
-            core.info('Search by the issue sentinel successfully.');
-            core.debug(`Response: ${prediction}`);
-            if (!prediction || prediction.length === 0) {
-                core.info('No prediction found');
-                return;
-            }
-            let message = 'Here are some similar issues that might help you. Please check if they can solve your problem.\n';
-            for (const item of prediction) {
-                message += `- #${item[item.length - 1]}\n`;
-            }
-            message = message.trimEnd();
-            const octokit = github.getOctokit(token);
-            const issueNumber = context.payload.issue.number;
-            yield octokit.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number: issueNumber,
-                body: message
-            });
-            core.info(`Comment sended to issue #${issueNumber}`);
-            const labels = ["Similar-Issue"];
-            yield octokit.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number: issueNumber,
-                labels
-            });
-            core.info(`Label added to issue #${issueNumber}`);
-            yield axios_1.default.post(botUrl + '/add_reply/', {
-                'repo': owner_repo,
-                'issue': issue.number,
-                'password': password
-            });
-            core.info('Save replied issue to issue sentinel.');
         }
         catch (error) {
             core.setFailed(error.message);

--- a/dist/index.js
+++ b/dist/index.js
@@ -31582,6 +31582,7 @@ function main() {
                 yield handleSimilarIssuesScanning(issue, owner, repo, password, token, botUrl, context);
             }
             if (enable_security_issues_scanning === 'true') {
+                core.info(`eventName: ${context.eventName}`);
                 yield handleSecurityIssuesScanning(issue, owner, repo, password, token, botUrl, context);
             }
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,6 @@ async function main() {
         const password = core.getInput('password');
         //TODO: use github token for authentication
         const token = core.getInput('github-token', { required: true });
-
         const enable_similar_issues_scanning = core.getInput('enable-similar-issues-scanning');
         const enable_security_issues_scanning = core.getInput('enable-security-issues-scanning');
         if (enable_similar_issues_scanning !== 'true' && enable_security_issues_scanning !== 'true') {
@@ -22,132 +21,141 @@ async function main() {
         const issue = context.payload.issue;
         core.debug(`Issue: ${JSON.stringify(issue)}`);
         const { owner, repo } = github.context.repo;
-        let owner_repo = `${owner}/${repo}`;
-        owner_repo = owner_repo.toLowerCase();
-        core.debug(`owner/repo: ${owner_repo}`);
 
         if (enable_similar_issues_scanning === 'true') {
-            const if_closed: boolean = issue.state === 'closed';
-            if (if_closed) {
-                await axios.post(botUrl + '/update_issue/', {
-                    'raw': issue,
-                    'password': password
-                })
-                core.info('This issue was closed. Update it to issue sentinel.');
-                return;
-            }
-    
-            const if_replied: boolean = (await axios.post(botUrl + '/check_reply/', {
-                'repo': owner_repo,
-                'issue': issue.number,
-                'password': password
-            })).data.result;
-            core.info('Check if this issue was already replied by the sentinel: ' + if_replied.toString());
-    
-            if (if_replied) {
-                await axios.post(botUrl + '/update_issue/', {
-                    'raw': issue,
-                    'password': password
-                })
-                core.info('This issue was already replied by the sentinel. Update the edited content to sentinel and skip this issue.');
-                return;
-            }
-
-            const prediction: any[][] = (await axios.post(botUrl + '/search/', {
-                'raw': issue,
-                'password': password,
-                'verify': true
-            })).data.predict;
-            core.info('Search by the issue sentinel successfully.');
-
-            core.debug(`Response: ${prediction}`);
-            if (!prediction || prediction.length === 0) {
-                core.info('No prediction found');
-                return;
-            }
-            let message = 'Here are some similar issues that might help you. Please check if they can solve your problem.\n'
-            for (const item of prediction) {
-                message += `- #${item[item.length - 1]}\n`
-            }
-            message = message.trimEnd();
-
-            const octokit = github.getOctokit(token);
-            const issueNumber = context.payload.issue.number;
-
-            await octokit.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number: issueNumber,
-                body: message
-            });
-            core.info(`Comment sended to issue #${issueNumber}`);
-
-            const labels = ["Similar-Issue"];
-            await octokit.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number: issueNumber,
-                labels
-            });
-            core.info(`Label added to issue #${issueNumber}`);
-
-            await axios.post(botUrl + '/add_reply/', {
-                'repo': owner_repo,
-                'issue': issue.number,
-                'password': password
-            });
-            core.info('Save replied issue to issue sentinel.');
+            await handleSimilarIssuesScanning(issue, owner, repo, password, token, botUrl, context);
         }
 
         if (enable_security_issues_scanning === 'true') {
-            const octokit = github.getOctokit(token);
-            const issueNumber = context.payload.issue.number;
-            const { data: existedLabels } = await octokit.rest.issues.listLabelsOnIssue({
-                owner,
-                repo,
-                issue_number: issueNumber,
-            });
-            const labelExists = existedLabels.some((label: { name: string }) => label.name === "Security-Issue");
-            
-            if (labelExists) {
-                core.info('This issue has already been labeled as Security-Issue. Skip this issue.');
-                return;
-            }
-            
-            const ifsecurity = (await axios.post(botUrl + '/security/', {
-                'raw': issue,
-                'password': password
-            })).data.predict;
-            core.info('Search the security issues by the issue sentinel successfully.');
-            core.debug(`Response: ${ifsecurity}`);
-
-            if (!ifsecurity) {
-                core.info('Not a security issue.');
-                return;
-            }
-
-            let message = 'This issue is related to security. Please pay attention.\n'
-            await octokit.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number: issueNumber,
-                body: message
-            });
-            core.info(`Comment sended to issue #${issueNumber}`);
-
-            const labels = ["Security-Issue"];
-            await octokit.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number: issueNumber,
-                labels
-            });
-            core.info(`Label added to issue #${issueNumber}`);
+            await handleSecurityIssuesScanning(issue, owner, repo, password, token, botUrl, context);
         }
     }
     catch (error: any) {
         core.setFailed(error.message);
     }
+}
+
+async function handleSimilarIssuesScanning(issue: any, owner: string, repo: string, password: string, token: string, botUrl: string, context: any) {
+    let owner_repo = `${owner}/${repo}`;
+    owner_repo = owner_repo.toLowerCase();
+    core.debug(`owner/repo: ${owner_repo}`);
+
+    const if_closed: boolean = issue.state === 'closed';
+    if (if_closed) {
+        await axios.post(botUrl + '/update_issue/', {
+            'raw': issue,
+            'password': password
+        })
+        core.info('This issue was closed. Update it to issue sentinel.');
+        return;
+    }
+
+    const if_replied: boolean = (await axios.post(botUrl + '/check_reply/', {
+        'repo': owner_repo,
+        'issue': issue.number,
+        'password': password
+    })).data.result;
+    core.info('Check if this issue was already replied by the sentinel: ' + if_replied.toString());
+
+    if (if_replied) {
+        await axios.post(botUrl + '/update_issue/', {
+            'raw': issue,
+            'password': password
+        })
+        core.info('This issue was already replied by the sentinel. Update the edited content to sentinel and skip this issue.');
+        return;
+    }
+
+    const prediction: any[][] = (await axios.post(botUrl + '/search/', {
+        'raw': issue,
+        'password': password,
+        'verify': true
+    })).data.predict;
+    core.info('Search by the issue sentinel successfully.');
+
+    core.debug(`Response: ${prediction}`);
+    if (!prediction || prediction.length === 0) {
+        core.info('No prediction found');
+        return;
+    }
+    let message = 'Here are some similar issues that might help you. Please check if they can solve your problem.\n'
+    for (const item of prediction) {
+        message += `- #${item[item.length - 1]}\n`
+    }
+    message = message.trimEnd();
+
+    const octokit = github.getOctokit(token);
+    const issueNumber = context.payload.issue.number;
+
+    await octokit.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: issueNumber,
+        body: message
+    });
+    core.info(`Comment sended to issue #${issueNumber}`);
+
+    const labels = ["Similar-Issue"];
+    await octokit.rest.issues.addLabels({
+        owner,
+        repo,
+        issue_number: issueNumber,
+        labels
+    });
+    core.info(`Label added to issue #${issueNumber}`);
+
+    await axios.post(botUrl + '/add_reply/', {
+        'repo': owner_repo,
+        'issue': issue.number,
+        'password': password
+    });
+    core.info('Save replied issue to issue sentinel.');
+}
+
+async function handleSecurityIssuesScanning(issue: any, owner: string, repo: string, password: string, token: string, botUrl: string, context: any) {  
+    const octokit = github.getOctokit(token);
+    const issueNumber = context.payload.issue.number;
+    const { data: existedLabels } = await octokit.rest.issues.listLabelsOnIssue({
+        owner,
+        repo,
+        issue_number: issueNumber,
+    });
+    const labelExists = existedLabels.some((label: { name: string }) => label.name === "Security-Issue");
+    
+    if (labelExists) {
+        core.info('This issue has already been labeled as Security-Issue. Skip this issue.');
+        return;
+    }
+    
+    const ifsecurity = (await axios.post(botUrl + '/security/', {
+        'raw': issue,
+        'password': password
+    })).data.predict;
+    core.info('Search the security issues by the issue sentinel successfully.');
+    core.debug(`Response: ${ifsecurity}`);
+
+    if (!ifsecurity) {
+        core.info('Not a security issue.');
+        return;
+    }
+
+    let message = 'This issue is related to security. Please pay attention.\n'
+    await octokit.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: issueNumber,
+        body: message
+    });
+    core.info(`Comment sended to issue #${issueNumber}`);
+
+    const labels = ["Security-Issue"];
+    await octokit.rest.issues.addLabels({
+        owner,
+        repo,
+        issue_number: issueNumber,
+        labels
+    });
+    core.info(`Label added to issue #${issueNumber}`);
 }
 
 main();  

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,14 +20,18 @@ async function main() {
         }
         const issue = context.payload.issue;
         core.debug(`Issue: ${JSON.stringify(issue)}`);
-        const { owner, repo } = github.context.repo;
+        const { owner, repo } = context.repo;
 
         if (enable_similar_issues_scanning === 'true') {
             await handleSimilarIssuesScanning(issue, owner, repo, password, token, botUrl, context);
         }
 
         if (enable_security_issues_scanning === 'true') {
-            core.info(`eventName: ${context.eventName}`)
+            core.debug(`Issue trigger: ${context.payload.action}`);
+            if (context.payload.action !== 'opened') {
+                core.info('Skip security issues scanning for edited and closed issue.');
+                return;
+            }
             await handleSecurityIssuesScanning(issue, owner, repo, password, token, botUrl, context);
         }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ async function main() {
         }
 
         if (enable_security_issues_scanning === 'true') {
+            core.info(`eventName: ${context.eventName}`)
             await handleSecurityIssuesScanning(issue, owner, repo, password, token, botUrl, context);
         }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,13 @@ async function main() {
     try {
         const password = core.getInput('password');
         //TODO: use github token for authentication
-        const token = core.getInput('github-token', { required: true })
+        const token = core.getInput('github-token', { required: true });
+
+        const enable_similar_issues_scanning = core.getInput('enable-similar-issues-scanning');
+        const enable_security_issues_scanning = core.getInput('enable-security-issues-scanning');
+        if (enable_similar_issues_scanning !== 'true' && enable_security_issues_scanning !== 'true') {
+            throw new Error('Invalid input! Both similar issues scanning and security issues scanning are disabled. Please enable at least one of them.');
+        }
 
         const botUrl = 'https://similar-bot-prod.calmhill-ec497646.eastus.azurecontainerapps.io';
         const context = github.context;
@@ -20,76 +26,124 @@ async function main() {
         owner_repo = owner_repo.toLowerCase();
         core.debug(`owner/repo: ${owner_repo}`);
 
-        const if_closed: boolean = issue.state === 'closed';
-        if (if_closed) {
-            await axios.post(botUrl + '/update_issue/', {
+        if (enable_similar_issues_scanning === 'true') {
+            const if_closed: boolean = issue.state === 'closed';
+            if (if_closed) {
+                await axios.post(botUrl + '/update_issue/', {
+                    'raw': issue,
+                    'password': password
+                })
+                core.info('This issue was closed. Update it to issue sentinel.');
+                return;
+            }
+    
+            const if_replied: boolean = (await axios.post(botUrl + '/check_reply/', {
+                'repo': owner_repo,
+                'issue': issue.number,
+                'password': password
+            })).data.result;
+            core.info('Check if this issue was already replied by the sentinel: ' + if_replied.toString());
+    
+            if (if_replied) {
+                await axios.post(botUrl + '/update_issue/', {
+                    'raw': issue,
+                    'password': password
+                })
+                core.info('This issue was already replied by the sentinel. Update the edited content to sentinel and skip this issue.');
+                return;
+            }
+
+            const prediction: any[][] = (await axios.post(botUrl + '/search/', {
+                'raw': issue,
+                'password': password,
+                'verify': true
+            })).data.predict;
+            core.info('Search by the issue sentinel successfully.');
+
+            core.debug(`Response: ${prediction}`);
+            if (!prediction || prediction.length === 0) {
+                core.info('No prediction found');
+                return;
+            }
+            let message = 'Here are some similar issues that might help you. Please check if they can solve your problem.\n'
+            for (const item of prediction) {
+                message += `- #${item[item.length - 1]}\n`
+            }
+            message = message.trimEnd();
+
+            const octokit = github.getOctokit(token);
+            const issueNumber = context.payload.issue.number;
+
+            await octokit.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body: message
+            });
+            core.info(`Comment sended to issue #${issueNumber}`);
+
+            const labels = ["Similar-Issue"];
+            await octokit.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                labels
+            });
+            core.info(`Label added to issue #${issueNumber}`);
+
+            await axios.post(botUrl + '/add_reply/', {
+                'repo': owner_repo,
+                'issue': issue.number,
+                'password': password
+            });
+            core.info('Save replied issue to issue sentinel.');
+        }
+
+        if (enable_security_issues_scanning === 'true') {
+            const octokit = github.getOctokit(token);
+            const issueNumber = context.payload.issue.number;
+            const { data: existedLabels } = await octokit.rest.issues.listLabelsOnIssue({
+                owner,
+                repo,
+                issue_number: issueNumber,
+            });
+            const labelExists = existedLabels.some((label: { name: string }) => label.name === "Security-Issue");
+            
+            if (labelExists) {
+                core.info('This issue has already been labeled as Security-Issue. Skip this issue.');
+                return;
+            }
+            
+            const ifsecurity = (await axios.post(botUrl + '/security/', {
                 'raw': issue,
                 'password': password
-            })
-            core.info('This issue was closed. Update it to issue sentinel.');
-            return;
+            })).data.predict;
+            core.info('Search the security issues by the issue sentinel successfully.');
+            core.debug(`Response: ${ifsecurity}`);
+
+            if (!ifsecurity) {
+                core.info('Not a security issue.');
+                return;
+            }
+
+            let message = 'This issue is related to security. Please pay attention.\n'
+            await octokit.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body: message
+            });
+            core.info(`Comment sended to issue #${issueNumber}`);
+
+            const labels = ["Security-Issue"];
+            await octokit.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                labels
+            });
+            core.info(`Label added to issue #${issueNumber}`);
         }
-
-        const if_replied: boolean = (await axios.post(botUrl + '/check_reply/', {
-            'repo': owner_repo,
-            'issue': issue.number,
-            'password': password
-        })).data.result;
-        core.info('Check if this issue was already replied by the sentinel: ' + if_replied.toString());
-
-        if (if_replied) {
-            await axios.post(botUrl + '/update_issue/', {
-                'raw': issue,
-                'password': password
-            })
-            core.info('This issue was already replied by the sentinel. Update the edited content to sentinel and skip this issue.');
-            return;
-        }
-
-        const prediction: any[][] = (await axios.post(botUrl + '/search/', {
-            'raw': issue,
-            'password': password,
-            'verify': true
-        })).data.predict;
-        core.info('Search by the issue sentinel successfully.');
-
-        core.debug(`Response: ${prediction}`);
-        if (!prediction || prediction.length === 0) {
-            core.info('No prediction found');
-            return;
-        }
-        let message = 'Here are some similar issues that might help you. Please check if they can solve your problem.\n'
-        for (const item of prediction) {
-            message += `- #${item[item.length - 1]}\n`
-        }
-        message = message.trimEnd();
-
-        const octokit = github.getOctokit(token);
-        const issueNumber = context.payload.issue.number;
-
-        await octokit.rest.issues.createComment({
-            owner,
-            repo,
-            issue_number: issueNumber,
-            body: message
-        });
-        core.info(`Comment sended to issue #${issueNumber}`);
-
-        const labels = ["Similar-Issue"];
-        await octokit.rest.issues.addLabels({
-            owner,
-            repo,
-            issue_number: issueNumber,
-            labels
-        });
-        core.info(`Label added to issue #${issueNumber}`);
-
-        await axios.post(botUrl + '/add_reply/', {
-            'repo': owner_repo,
-            'issue': issue.number,
-            'password': password
-        });
-        core.info('Save replied issue to issue sentinel.');
     }
     catch (error: any) {
         core.setFailed(error.message);

--- a/src/main.ts
+++ b/src/main.ts
@@ -127,14 +127,14 @@ async function handleSecurityIssuesScanning(issue: any, owner: string, repo: str
         return;
     }
     
-    const ifsecurity = (await axios.post(botUrl + '/security/', {
+    const if_security = (await axios.post(botUrl + '/security/', {
         'raw': issue,
         'password': password
-    })).data.predict;
+    })).data.security;
     core.info('Search the security issues by the issue sentinel successfully.');
-    core.debug(`Response: ${ifsecurity}`);
+    core.debug(`Response: ${if_security}`);
 
-    if (!ifsecurity) {
+    if (!if_security) {
         core.info('Not a security issue.');
         return;
     }


### PR DESCRIPTION
Add two parameters in the action.
```yaml
enable-similar-issues-scanning: 
  description: 'Enable similar issues scanning'
  default: 'true'
  required: false
enable-security-issues-scanning: 
  description: 'Enable security issues scanning'
  default: 'false'
  required: false
```
When the issue is related to security, the bot will comment "This issue is related to security. Please pay attention." and add the "Security-Issue" label to this issue.

Test: https://github.com/MoChilia/ActionDemo/issues/18