### PR TITLE
Fix live-test workflow azdev setup execution

### DIFF
--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -130,9 +130,11 @@ jobs:
         working-directory: azure-cli
         run: |
           set -euo pipefail
+          python -m venv .venv
+          source .venv/bin/activate
           python -m pip install --upgrade pip
           python -m pip install azdev
-          azdev setup --cli .
+          azdev setup -c azure-cli
 
       - name: Azure login (BAMI tenant, federated OIDC)
         uses: azure/login@v2
@@ -148,6 +150,7 @@ jobs:
         env:
           MODULE: ${{ steps.detect.outputs.module }}
         run: |
+          source .venv/bin/activate
           set -o pipefail
           mkdir -p ../test-output
           set +e

--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -134,7 +134,7 @@ jobs:
           source .venv/bin/activate
           python -m pip install --upgrade pip
           python -m pip install azdev
-          azdev setup -c azure-cli
+          azdev setup -c .
 
       - name: Azure login (BAMI tenant, federated OIDC)
         uses: azure/login@v2


### PR DESCRIPTION
**Summary**
- run `azdev` inside a project venv in live-test workflow
- fix CLI setup path from `azdev setup -c azure-cli` to `azdev setup -c .`

**Why**
- previous runs failed before testing with:
  - `TypeError: expected str, bytes or os.PathLike object, not NoneType` from azdev setup
  - then `.../azure-cli/azure-cli is not a valid path`

**Validation**
- dispatched workflow on branch with `post_comment=false`
- run progressed through setup and reached Azure login stage
- branch run failed at OIDC (`AADSTS700213`) because federated credential is configured for `refs/heads/main`, which is expected for non-main refs

After merge to `main`, the same workflow path should use the allowed OIDC subject and proceed to live test execution.