### PR TITLE
Switch KV vault to azclibotfinegrainedpat for fine-grained PAT

### DIFF
--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           set -euo pipefail
           pat=$(az keyvault secret show \
-            --vault-name kv-azuresdk \
+            --vault-name azclibotfinegrainedpat \
             --name azclibot-pat \
             --query value -o tsv)
           echo "::add-mask::${pat}"


### PR DESCRIPTION
Updates live-test.yml to fetch the GitHub PAT from azclibotfinegrainedpat instead of kv-azuresdk, so the workflow uses a fine-grained PAT accepted by the Copilot SDK.